### PR TITLE
add ProduceWithContext

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -57,9 +57,13 @@ func NewProducer(conf *kafka.ConfigMap, opts ...Option) (*Producer, error) {
 
 // Produce calls the underlying Producer.Produce and traces the request.
 func (p *Producer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) error {
+	return p.ProduceWithContext(context.Background(), msg, deliveryChan)
+}
+
+func (p *Producer) ProduceWithContext(context context.Context, msg *kafka.Message, deliveryChan chan kafka.Event) error {
 	// If there's a span context in the message, use that as the parent context.
 	carrier := NewMessageCarrier(msg)
-	ctx := p.cfg.Propagators.Extract(context.Background(), carrier)
+	ctx := p.cfg.Propagators.Extract(context, carrier)
 	start := time.Now()
 
 	lowCardinalityAttrs := []attribute.KeyValue{


### PR DESCRIPTION
I'd like to pass the parent context to the `otelkafka.Producer`.

I'm running a system like the following below.

1. Server receives a HTTP request (span A)
1. Server produces a message to Kafka (span B)

Currently, it seems likely that `span A` is not properly recognized as the parent of `span B`.
